### PR TITLE
ci(workflows): chain automerge after CI success using workflow_run; e…

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -4,8 +4,6 @@ on:
   workflow_dispatch: {}
   pull_request:
     types: [labeled]
-  check_suite:
-    types: [completed]
 
 permissions:
   contents: write
@@ -15,11 +13,8 @@ permissions:
 
 jobs:
   automerge:
-    # Ejecuta cuando se añade la etiqueta automerge o cuando todos los checks pasan
-    if: >-
-      (github.event_name == 'pull_request' && github.event.action == 'labeled' &&
-       github.event.label.name == 'automerge') ||
-      (github.event_name == 'check_suite' && github.event.check_suite.conclusion == 'success')
+    # Ejecuta únicamente cuando se añade la etiqueta automerge
+    if: github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'automerge'
     runs-on: ubuntu-latest
     steps:
       - name: Automerge

--- a/.github/workflows/label-automerge.yml
+++ b/.github/workflows/label-automerge.yml
@@ -1,8 +1,8 @@
 name: Label automerge PRs to master
 
 on:
-  workflow_dispatch: {}
-  check_suite:
+  workflow_run:
+    workflows: ["CI"]
     types: [completed]
 
 permissions:
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   label-automerge:
-    if: github.event_name == 'check_suite' && github.event.check_suite.conclusion == 'success'
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Add automerge label when all checks pass
@@ -22,7 +22,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             async function run() {
-              const sha = context.payload?.check_suite?.head_sha;
+              const sha = context.payload?.workflow_run?.head_sha;
               if (!sha) return;
               const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
                 owner: context.repo.owner,
@@ -34,9 +34,6 @@ jobs:
               );
               if (!targetPr) return;
 
-              // Si llegamos aquí, significa que todos los checks del check_suite pasaron
-              // porque el evento check_suite.completed con conclusion='success' solo se dispara
-              // cuando todos los checks están completos y exitosos
               if (targetPr.base.ref === 'master') {
                 await github.rest.issues.addLabels({
                   owner: context.repo.owner,


### PR DESCRIPTION
…nsure automerge only runs on label

- label-automerge.yml: trigger on workflow_run of CI completed with success; map head_sha from workflow_run; add label only for PRs to master
- automerge.yml: remove check_suite trigger and condition; run only when PR gets 'automerge' label